### PR TITLE
EdgeGap Requests

### DIFF
--- a/EdgegapIntegrationKit.uplugin
+++ b/EdgegapIntegrationKit.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "https://docs.edgegap.com/docs/",
 	"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/product/3d3e8e5a9f3f4f7fa0411d4fef2f7e25",
 	"SupportURL": "https://discord.gg/betidestudio",
-	"EngineVersion": "5.4.0",
+	"EngineVersion": "5.6.0",
 	"CanContainContent": true,
 	"IsBetaVersion": false,
 	"IsExperimentalVersion": false,

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Here're some of the project's best features:
 - Added GetGroupPlayerMapping function for retrieving player IDs by group ID
 - Added GetExpansionStage function to get expansion stage information
 - Added GetMatchProfileName function to get match profile name
+- Added AssignmentDetails field to Backfills creation blueprint for full assignment details support in JSON format
 - Fixed Dockerfile modification issue
 - Fixed compiler warnings with LOCTEXT_NAMESPACE definitions
 

--- a/Source/Edgegap/Private/EdgegapSettings.h
+++ b/Source/Edgegap/Private/EdgegapSettings.h
@@ -15,23 +15,23 @@ struct FEdgegapPortConfig
 	GENERATED_BODY()
 
 	// The internal port number
-	UPROPERTY(Config, EditAnywhere, DisplayName = "Port Number")
+	UPROPERTY(Config, EditAnywhere, Category = "Port Config", DisplayName = "Port Number")
 	int32 Port = 7777;
 
 	// The protocol for this port (TCP, UDP, TCP/UDP)
-	UPROPERTY(Config, EditAnywhere, DisplayName = "Protocol")
+	UPROPERTY(Config, EditAnywhere, Category = "Port Config", DisplayName = "Protocol")
 	FString Protocol = TEXT("TCP/UDP");
 
 	// Whether to check this port
-	UPROPERTY(Config, EditAnywhere, DisplayName = "Check Port") 
+	UPROPERTY(Config, EditAnywhere, Category = "Port Config", DisplayName = "Check Port") 
 	bool bToCheck = false;
 
 	// Whether to upgrade to TLS
-	UPROPERTY(Config, EditAnywhere, DisplayName = "TLS Upgrade")
+	UPROPERTY(Config, EditAnywhere, Category = "Port Config", DisplayName = "TLS Upgrade")
 	bool bTLSUpgrade = false;
 
 	// Name of the port
-	UPROPERTY(Config, EditAnywhere, DisplayName = "Port Name")
+	UPROPERTY(Config, EditAnywhere, Category = "Port Config", DisplayName = "Port Name")
 	FString Name = TEXT("gameport");
 };
 
@@ -41,15 +41,15 @@ struct FEdgegapEnvironmentVariable
 	GENERATED_BODY()
 
 	// The environment variable key
-	UPROPERTY(Config, EditAnywhere, DisplayName = "Key")
+	UPROPERTY(Config, EditAnywhere, Category = "Environment Variable", DisplayName = "Key")
 	FString Key;
 
 	// The environment variable value
-	UPROPERTY(Config, EditAnywhere, DisplayName = "Value")
+	UPROPERTY(Config, EditAnywhere, Category = "Environment Variable", DisplayName = "Value")
 	FString Value;
 
 	// Whether this variable contains sensitive information
-	UPROPERTY(Config, EditAnywhere, DisplayName = "Is Hidden")
+	UPROPERTY(Config, EditAnywhere, Category = "Environment Variable", DisplayName = "Is Hidden")
 	bool bIsHidden = false;
 };
 

--- a/Source/EdgegapIntegrationKit/AsyncFunctions/Backfills/EGIK_CreateBackfill.h
+++ b/Source/EdgegapIntegrationKit/AsyncFunctions/Backfills/EGIK_CreateBackfill.h
@@ -57,6 +57,13 @@ struct FEGIK_CreateBackFillResponse
 
 	UPROPERTY(BlueprintReadWrite, Category = "Edgegap Integration Kit | Backfill")
 	FEGIK_MatchmakingResponse AssignedTicket;
+
+	UPROPERTY(BlueprintReadWrite, Category = "Edgegap Integration Kit | Backfill")
+	FEGIK_AssignmentStruct Assignment;
+
+	/** Raw JSON string of attributes.assignment for flexible handling of variable structures */
+	UPROPERTY(BlueprintReadWrite, Category = "Edgegap Integration Kit | Backfill")
+	FString AssignmentDetailsJson;
 };
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FCreateBackfillResponse, const FEGIK_CreateBackFillResponse&, Response, const FEGIK_ErrorStruct&, Error);
@@ -77,6 +84,9 @@ public:
 
 	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Backfill")
 	FCreateBackfillResponse OnFailure;
+
+	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Backfill")
+	FCreateBackfillResponse OnRateLimited;
 
 	void OnResponseReceived(TSharedPtr<IHttpRequest> HttpRequest, TSharedPtr<IHttpResponse> HttpResponse, bool bArg);
 	virtual void Activate() override;

--- a/Source/EdgegapIntegrationKit/AsyncFunctions/Backfills/EGIK_DeleteBackFillTicket.cpp
+++ b/Source/EdgegapIntegrationKit/AsyncFunctions/Backfills/EGIK_DeleteBackFillTicket.cpp
@@ -21,13 +21,19 @@ void UEGIK_DeleteBackFillTicket::OnResponseReceived(TSharedPtr<IHttpRequest> Htt
 	FEGIK_ErrorStruct Error;
 	if (HttpResponse.IsValid())
 	{
-		if (EHttpResponseCodes::IsOk(HttpResponse->GetResponseCode()))
+		const int32 ResponseCode = HttpResponse->GetResponseCode();
+		if (EHttpResponseCodes::IsOk(ResponseCode))
 		{
 			OnSuccess.Broadcast(FEGIK_ErrorStruct());
 		}
+		else if(ResponseCode == 429)
+		{
+			// 429 Too Many Requests - Rate limiting response
+			OnRateLimited.Broadcast(FEGIK_ErrorStruct(429, HttpResponse->GetContentAsString()));
+		}
 		else
 		{
-			OnFailure.Broadcast(FEGIK_ErrorStruct(HttpResponse->GetResponseCode(), HttpResponse->GetContentAsString()));
+			OnFailure.Broadcast(FEGIK_ErrorStruct(ResponseCode, HttpResponse->GetContentAsString()));
 		}
 	}
 	else

--- a/Source/EdgegapIntegrationKit/AsyncFunctions/Backfills/EGIK_DeleteBackFillTicket.h
+++ b/Source/EdgegapIntegrationKit/AsyncFunctions/Backfills/EGIK_DeleteBackFillTicket.h
@@ -29,6 +29,9 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Backfill")
 	FDeleteBackFillTicketResponse OnFailure;
 
+	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Backfill")
+	FDeleteBackFillTicketResponse OnRateLimited;
+
 private:
 	FString Var_BackfillId;
 	FString Var_MatchmakingURL;

--- a/Source/EdgegapIntegrationKit/AsyncFunctions/Backfills/EGIK_GetBackFillTicketInformation.cpp
+++ b/Source/EdgegapIntegrationKit/AsyncFunctions/Backfills/EGIK_GetBackFillTicketInformation.cpp
@@ -22,7 +22,8 @@ void UEGIK_GetBackFillTicketInformation::OnResponseReceived(TSharedPtr<IHttpRequ
 	if (HttpResponse.IsValid())
 	{
 		UE_LOG(LogTemp, Warning, TEXT("Response: %s"), *HttpResponse->GetContentAsString());
-		if (EHttpResponseCodes::IsOk(HttpResponse->GetResponseCode()))
+		const int32 ResponseCode = HttpResponse->GetResponseCode();
+		if (EHttpResponseCodes::IsOk(ResponseCode))
 		{
 			TSharedPtr<FJsonObject> JsonObject;
 			TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(HttpResponse->GetContentAsString());
@@ -47,6 +48,42 @@ void UEGIK_GetBackFillTicketInformation::OnResponseReceived(TSharedPtr<IHttpRequ
 					Response.AssignedTicket = JsonObject->GetObjectField(TEXT("assigned_ticket")); 
 				}
 
+				// Parse assignment details from attributes.assignment
+				const TSharedPtr<FJsonObject>* AttributesObject;
+				if (JsonObject->TryGetObjectField(TEXT("attributes"), AttributesObject))
+				{
+					const TSharedPtr<FJsonObject>* AssignmentObject;
+					if ((*AttributesObject)->HasTypedField<EJson::Object>(TEXT("assignment")))
+					{
+						if ((*AttributesObject)->TryGetObjectField(TEXT("assignment"), AssignmentObject))
+						{
+							// Store raw JSON string for flexible handling of variable structures
+							FString AssignmentJsonString;
+							TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&AssignmentJsonString);
+							FJsonSerializer::Serialize((*AssignmentObject).ToSharedRef(), Writer);
+							Response.AssignmentDetailsJson = AssignmentJsonString;
+							
+							// Try to parse into structured format (will gracefully handle missing fields)
+							Response.Assignment = FEGIK_AssignmentStruct(*AssignmentObject);
+						}
+						else
+						{
+							Response.Assignment = FEGIK_AssignmentStruct("null");
+							Response.AssignmentDetailsJson = "";
+						}
+					}
+					else
+					{
+						Response.Assignment = FEGIK_AssignmentStruct("null");
+						Response.AssignmentDetailsJson = "";
+					}
+				}
+				else
+				{
+					Response.Assignment = FEGIK_AssignmentStruct("null");
+					Response.AssignmentDetailsJson = "";
+				}
+
 				OnSuccess.Broadcast(Response, FEGIK_ErrorStruct());
 			}
 			else
@@ -54,9 +91,14 @@ void UEGIK_GetBackFillTicketInformation::OnResponseReceived(TSharedPtr<IHttpRequ
 				OnFailure.Broadcast(FEGIK_GetBackFillTicketInformationResponse(), FEGIK_ErrorStruct(0, "Failed to parse JSON"));
 			}
 		}
+		else if(ResponseCode == 429)
+		{
+			// 429 Too Many Requests - Rate limiting response
+			OnRateLimited.Broadcast(FEGIK_GetBackFillTicketInformationResponse(), FEGIK_ErrorStruct(429, HttpResponse->GetContentAsString()));
+		}
 		else
 		{
-			OnFailure.Broadcast(FEGIK_GetBackFillTicketInformationResponse(), FEGIK_ErrorStruct(HttpResponse->GetResponseCode(), HttpResponse->GetContentAsString()));
+			OnFailure.Broadcast(FEGIK_GetBackFillTicketInformationResponse(), FEGIK_ErrorStruct(ResponseCode, HttpResponse->GetContentAsString()));
 		}
 	}
 	else

--- a/Source/EdgegapIntegrationKit/AsyncFunctions/Backfills/EGIK_GetBackFillTicketInformation.h
+++ b/Source/EdgegapIntegrationKit/AsyncFunctions/Backfills/EGIK_GetBackFillTicketInformation.h
@@ -28,6 +28,13 @@ struct FEGIK_GetBackFillTicketInformationResponse
 
 	UPROPERTY(BlueprintReadWrite, Category = "Edgegap Integration Kit | Backfill")
 	FEGIK_MatchmakingResponse AssignedTicket;
+
+	UPROPERTY(BlueprintReadWrite, Category = "Edgegap Integration Kit | Backfill")
+	FEGIK_AssignmentStruct Assignment;
+
+	/** Raw JSON string of attributes.assignment for flexible handling of variable structures */
+	UPROPERTY(BlueprintReadWrite, Category = "Edgegap Integration Kit | Backfill")
+	FString AssignmentDetailsJson;
 	
 };
 
@@ -50,6 +57,9 @@ public:
 
 	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Backfill")
 	FGetBackFillTicketInformationResponse OnFailure;
+
+	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Backfill")
+	FGetBackFillTicketInformationResponse OnRateLimited;
 
 private:
 	FString Var_BackfillId;

--- a/Source/EdgegapIntegrationKit/AsyncFunctions/EGIK_CreateMatchmakingTicket.h
+++ b/Source/EdgegapIntegrationKit/AsyncFunctions/EGIK_CreateMatchmakingTicket.h
@@ -31,6 +31,9 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Matchmaking")
 	FCreateMatchmakingTicketResponse OnFailure;
 
+	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Matchmaking")
+	FCreateMatchmakingTicketResponse OnRateLimited;
+
 private:
 	FEGIK_CreateMatchmakingStruct Var_MatchmakingStruct;
 };

--- a/Source/EdgegapIntegrationKit/AsyncFunctions/EGIK_DeleteMatchmakingTicket.cpp
+++ b/Source/EdgegapIntegrationKit/AsyncFunctions/EGIK_DeleteMatchmakingTicket.cpp
@@ -23,6 +23,11 @@ void UEGIK_DeleteMatchmakingTicket::OnResponseReceived(TSharedPtr<IHttpRequest> 
 			// 204 No Content indicates successful deletion
 			OnSuccess.Broadcast(FEGIK_ErrorStruct());
 		}
+		else if(ResponseCode == 429)
+		{
+			// 429 Too Many Requests - Rate limiting response
+			OnRateLimited.Broadcast(FEGIK_ErrorStruct(429, HttpResponse->GetContentAsString()));
+		}
 		else if(ResponseCode == 409)
 		{
 			// 409 Conflict indicates the ticket cannot be deleted because deployment is starting

--- a/Source/EdgegapIntegrationKit/AsyncFunctions/EGIK_DeleteMatchmakingTicket.h
+++ b/Source/EdgegapIntegrationKit/AsyncFunctions/EGIK_DeleteMatchmakingTicket.h
@@ -43,6 +43,9 @@ public:
 
 	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Matchmaking")
 	FDeleteMatchmakingTicketResponse OnFailure;
+
+	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Matchmaking")
+	FDeleteMatchmakingTicketResponse OnRateLimited;
 	
 private:
 	FEGIK_DeleteMatchmakingRequest Var_Request;

--- a/Source/EdgegapIntegrationKit/AsyncFunctions/EGIK_GetMatchmakingTicket.h
+++ b/Source/EdgegapIntegrationKit/AsyncFunctions/EGIK_GetMatchmakingTicket.h
@@ -41,6 +41,9 @@ public:
 
 	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Matchmaking")
 	FGetMatchmakingTicketResponse OnFailure;
+
+	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Matchmaking")
+	FGetMatchmakingTicketResponse OnRateLimited;
 	
 private:
 	FEGIK_MatchmakingRequest Var_MatchmakingRequest;

--- a/Source/EdgegapIntegrationKit/AsyncFunctions/Group/EGIK_CreateGroupTicket.cpp
+++ b/Source/EdgegapIntegrationKit/AsyncFunctions/Group/EGIK_CreateGroupTicket.cpp
@@ -17,7 +17,8 @@ void UEGIK_CreateGroupTicket::OnResponseReceived(TSharedPtr<IHttpRequest> HttpRe
 	TArray<FEGIK_MatchmakingResponse> ResponseArray;
 	if(HttpResponse.IsValid())
 	{
-		if(EHttpResponseCodes::IsOk(HttpResponse->GetResponseCode()))
+		const int32 ResponseCode = HttpResponse->GetResponseCode();
+		if(EHttpResponseCodes::IsOk(ResponseCode))
 		{
 			TSharedPtr<FJsonObject> JsonObject;
 			TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(HttpResponse->GetContentAsString());
@@ -73,9 +74,14 @@ void UEGIK_CreateGroupTicket::OnResponseReceived(TSharedPtr<IHttpRequest> HttpRe
 				OnFailure.Broadcast(TArray<FEGIK_MatchmakingResponse>(), FEGIK_ErrorStruct(0, "Failed to parse JSON"));
 			}
 		}
+		else if(ResponseCode == 429)
+		{
+			// 429 Too Many Requests - Rate limiting response
+			OnRateLimited.Broadcast(TArray<FEGIK_MatchmakingResponse>(), FEGIK_ErrorStruct(429, HttpResponse->GetContentAsString()));
+		}
 		else
 		{
-			OnFailure.Broadcast(TArray<FEGIK_MatchmakingResponse>(), FEGIK_ErrorStruct(HttpResponse->GetResponseCode(), HttpResponse->GetContentAsString()));
+			OnFailure.Broadcast(TArray<FEGIK_MatchmakingResponse>(), FEGIK_ErrorStruct(ResponseCode, HttpResponse->GetContentAsString()));
 		}
 	}
 }

--- a/Source/EdgegapIntegrationKit/AsyncFunctions/Group/EGIK_CreateGroupTicket.h
+++ b/Source/EdgegapIntegrationKit/AsyncFunctions/Group/EGIK_CreateGroupTicket.h
@@ -73,6 +73,9 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Group")
 	FEGIK_CreateGroupMatchmakingTicketResponse OnFailure;
 
+	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Group")
+	FEGIK_CreateGroupMatchmakingTicketResponse OnRateLimited;
+
 private:
 	FEGIK_CreateGroupTicketRequest Var_Request;
 	

--- a/Source/EdgegapIntegrationKit/Private/EdgegapServerShutdownSubsystem.cpp
+++ b/Source/EdgegapIntegrationKit/Private/EdgegapServerShutdownSubsystem.cpp
@@ -1,0 +1,268 @@
+// Copyright (c) 2024 Betide Studio. All Rights Reserved.
+
+#include "EdgegapServerShutdownSubsystem.h"
+#include "HttpModule.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+#include "EGIKBlueprintFunctionLibrary.h"
+#include "HAL/PlatformProcess.h"
+#include "GenericPlatform/GenericPlatformCrashContext.h"
+#include "Misc/App.h"
+#include "Engine/Engine.h"
+#include "Misc/CoreDelegates.h"
+#include "HAL/IConsoleManager.h"
+#include "Engine/GameInstance.h"
+#include "GenericPlatform/GenericPlatformMisc.h"
+#include "Engine/World.h"
+#include "TimerManager.h"
+
+void UEdgegapServerShutdownSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+	
+	bShutdownInitiated = false;
+	
+	// Check if we're running on Edgegap by looking for request ID in various possible environment variables
+	// Edgegap/Arbitrium may use different variable names
+	CachedRequestID = FPlatformMisc::GetEnvironmentVariable(TEXT("EG_REQUEST_ID"));
+	if (CachedRequestID.IsEmpty())
+	{
+		CachedRequestID = FPlatformMisc::GetEnvironmentVariable(TEXT("EDGEGAP_REQUEST_ID"));
+	}
+	if (CachedRequestID.IsEmpty())
+	{
+		CachedRequestID = FPlatformMisc::GetEnvironmentVariable(TEXT("EDGE_REQUEST_ID"));
+	}
+	if (CachedRequestID.IsEmpty())
+	{
+		CachedRequestID = FPlatformMisc::GetEnvironmentVariable(TEXT("ARBITRIUM_REQUEST_ID"));
+	}
+	
+	bIsEdgegapEnvironment = !CachedRequestID.IsEmpty();
+	
+	if (bIsEdgegapEnvironment)
+	{
+		UE_LOG(LogTemp, Log, TEXT("EdgegapServerShutdown: Detected Edgegap environment. Request ID: %s"), *CachedRequestID);
+		
+		// Setup shutdown hooks
+		SetupShutdownHooks();
+		
+		// Setup crash handlers
+		SetupCrashHandlers();
+	}
+	else
+	{
+		UE_LOG(LogTemp, Log, TEXT("EdgegapServerShutdown: Not running on Edgegap (no request ID found)"));
+	}
+}
+
+void UEdgegapServerShutdownSubsystem::Deinitialize()
+{
+	// Call self-stop API on shutdown if not already called
+	if (bIsEdgegapEnvironment && !bShutdownInitiated)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("EdgegapServerShutdown: Deinitialize called without explicit shutdown, calling self-stop API"));
+		CallSelfStopAPI(false);
+	}
+	
+	Super::Deinitialize();
+}
+
+bool UEdgegapServerShutdownSubsystem::IsRunningOnEdgegap() const
+{
+	return bIsEdgegapEnvironment;
+}
+
+bool UEdgegapServerShutdownSubsystem::GetDeploymentRequestID(FString& RequestID) const
+{
+	if (bIsEdgegapEnvironment)
+	{
+		RequestID = CachedRequestID;
+		return true;
+	}
+	return false;
+}
+
+void UEdgegapServerShutdownSubsystem::CallSelfStopAPI(bool bWaitForResponse)
+{
+	if (bShutdownInitiated)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("EdgegapServerShutdown: Self-stop API already called, ignoring duplicate call"));
+		return;
+	}
+	
+	if (!bIsEdgegapEnvironment || CachedRequestID.IsEmpty())
+	{
+		UE_LOG(LogTemp, Warning, TEXT("EdgegapServerShutdown: Cannot call self-stop API - not running on Edgegap or no request ID"));
+		OnServerShutdown.Broadcast(false, TEXT("Not running on Edgegap environment"));
+		return;
+	}
+	
+	bShutdownInitiated = true;
+	StopDeploymentInternal(CachedRequestID);
+	
+	if (bWaitForResponse)
+	{
+		// Wait up to 5 seconds for response
+		float ElapsedTime = 0.0f;
+		const float MaxWaitTime = 5.0f;
+		
+		if (UWorld* World = GetWorld())
+		{
+			while (ElapsedTime < MaxWaitTime && ShutdownRequest.IsValid())
+			{
+				World->GetTimerManager().Tick(0.1f);
+				ElapsedTime += 0.1f;
+			}
+		}
+	}
+}
+
+void UEdgegapServerShutdownSubsystem::StopDeploymentInternal(const FString& RequestID)
+{
+	FHttpModule* Http = &FHttpModule::Get();
+	if (!Http)
+	{
+		UE_LOG(LogTemp, Error, TEXT("EdgegapServerShutdown: Could not get HTTP module"));
+		OnServerShutdown.Broadcast(false, TEXT("Failed to initialize HTTP module"));
+		return;
+	}
+	
+	FString AuthorizationKey = UEGIKBlueprintFunctionLibrary::GetAuthorizationKey();
+	if (AuthorizationKey.IsEmpty())
+	{
+		UE_LOG(LogTemp, Error, TEXT("EdgegapServerShutdown: Authorization key not found"));
+		OnServerShutdown.Broadcast(false, TEXT("Authorization key not configured"));
+		return;
+	}
+	
+	FString URL = FString::Printf(TEXT("https://api.edgegap.com/v1/stop/%s"), *RequestID);
+	
+	ShutdownRequest = Http->CreateRequest();
+	ShutdownRequest->SetURL(URL);
+	ShutdownRequest->SetVerb("DELETE");
+	ShutdownRequest->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
+	ShutdownRequest->SetHeader(TEXT("Authorization"), *AuthorizationKey);
+	ShutdownRequest->SetTimeout(5); // 5 second timeout
+	
+	ShutdownRequest->OnProcessRequestComplete().BindUObject(this, &UEdgegapServerShutdownSubsystem::OnShutdownResponseReceived);
+	
+	UE_LOG(LogTemp, Log, TEXT("EdgegapServerShutdown: Calling self-stop API for request ID: %s"), *RequestID);
+	
+	if (!ShutdownRequest->ProcessRequest())
+	{
+		UE_LOG(LogTemp, Error, TEXT("EdgegapServerShutdown: Failed to process shutdown request"));
+		OnServerShutdown.Broadcast(false, TEXT("Failed to process HTTP request"));
+		ShutdownRequest.Reset();
+	}
+}
+
+void UEdgegapServerShutdownSubsystem::OnShutdownResponseReceived(TSharedPtr<IHttpRequest> HttpRequest, TSharedPtr<IHttpResponse> HttpResponse, bool bArg)
+{
+	bool bSuccess = false;
+	FString Message;
+	
+	if (HttpResponse.IsValid())
+	{
+		int32 ResponseCode = HttpResponse->GetResponseCode();
+		if (ResponseCode >= 200 && ResponseCode < 300)
+		{
+			bSuccess = true;
+			Message = FString::Printf(TEXT("Successfully called self-stop API (Response: %d)"), ResponseCode);
+			UE_LOG(LogTemp, Log, TEXT("EdgegapServerShutdown: %s"), *Message);
+		}
+		else
+		{
+			Message = FString::Printf(TEXT("Self-stop API returned error code: %d"), ResponseCode);
+			UE_LOG(LogTemp, Warning, TEXT("EdgegapServerShutdown: %s"), *Message);
+		}
+	}
+	else
+	{
+		Message = TEXT("Self-stop API request failed or no response received");
+		UE_LOG(LogTemp, Warning, TEXT("EdgegapServerShutdown: %s"), *Message);
+	}
+	
+	ShutdownRequest.Reset();
+	OnServerShutdown.Broadcast(bSuccess, Message);
+}
+
+void UEdgegapServerShutdownSubsystem::SetupShutdownHooks()
+{
+	// Register console command for RequestExit
+	// Note: Using a lambda to capture 'this' since the command is registered statically
+	IConsoleManager::Get().RegisterConsoleCommand(
+		TEXT("Edgegap.RequestExit"),
+		TEXT("Request server exit and call self-stop API"),
+		FConsoleCommandDelegate::CreateLambda([this]()
+		{
+			HandleRequestExitCommand();
+		})
+	);
+	
+	// Hook into PreExit to catch application termination
+	FCoreDelegates::OnPreExit.AddLambda([this]()
+	{
+		if (!bShutdownInitiated)
+		{
+			UE_LOG(LogTemp, Log, TEXT("EdgegapServerShutdown: PreExit detected, calling self-stop API"));
+			CallSelfStopAPI(false);
+		}
+	});
+	
+	// Hook into Engine shutdown
+	FCoreDelegates::OnExit.AddLambda([this]()
+	{
+		if (!bShutdownInitiated)
+		{
+			UE_LOG(LogTemp, Log, TEXT("EdgegapServerShutdown: Engine exit detected, calling self-stop API"));
+			CallSelfStopAPI(false);
+		}
+	});
+}
+
+void UEdgegapServerShutdownSubsystem::HandleRequestExitCommand()
+{
+	UE_LOG(LogTemp, Log, TEXT("EdgegapServerShutdown: RequestExit command received"));
+	CallSelfStopAPI(true);
+	
+	// Request engine exit after calling stop API
+	if (GEngine)
+	{
+		FGenericPlatformMisc::RequestExit(false);
+	}
+}
+
+void UEdgegapServerShutdownSubsystem::SetupCrashHandlers()
+{
+	// Set up crash handler using a lambda wrapper since the signature may vary
+	FCoreDelegates::OnHandleSystemError.AddLambda([]()
+	{
+		StaticCrashHandler(TEXT("System error detected"), false);
+	});
+}
+
+void UEdgegapServerShutdownSubsystem::StaticCrashHandler(const TCHAR* ErrorMessage, bool bIsAssert)
+{
+	// Try to call self-stop API on crash
+	// Note: This is a best-effort attempt as the process may terminate quickly
+	UE_LOG(LogTemp, Error, TEXT("EdgegapServerShutdown: Crash detected - %s"), ErrorMessage);
+	
+	// Try to get the subsystem and call stop API
+	// This may not always work during crash, but we try
+	// Access GameInstance through the world if available
+	if (GEngine && GWorld)
+	{
+		if (UGameInstance* GameInstance = GWorld->GetGameInstance())
+		{
+			if (UEdgegapServerShutdownSubsystem* Subsystem = GameInstance->GetSubsystem<UEdgegapServerShutdownSubsystem>())
+			{
+				if (!Subsystem->bShutdownInitiated)
+				{
+					Subsystem->CallSelfStopAPI(false);
+				}
+			}
+		}
+	}
+}
+

--- a/Source/EdgegapIntegrationKit/Public/EdgegapServerShutdownSubsystem.h
+++ b/Source/EdgegapIntegrationKit/Public/EdgegapServerShutdownSubsystem.h
@@ -1,0 +1,83 @@
+// Copyright (c) 2024 Betide Studio. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "Interfaces/IHttpRequest.h"
+#include "Interfaces/IHttpResponse.h"
+#include "EdgegapServerShutdownSubsystem.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnServerShutdown, bool, bSuccess, FString, Message);
+
+/**
+ * Subsystem to handle server shutdown and self-stop API calls
+ * Automatically calls Edgegap's self-stop API when the server exits
+ */
+UCLASS()
+class EDGEGAPINTEGRATIONKIT_API UEdgegapServerShutdownSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+
+	/**
+	 * Call the Edgegap self-stop API
+	 * @param bWaitForResponse - If true, will wait up to 5 seconds for the API response
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Edgegap Integration Kit | Server")
+	void CallSelfStopAPI(bool bWaitForResponse = false);
+
+	/**
+	 * Check if the server is running in Edgegap environment
+	 * @return True if EDGEGAP_REQUEST_ID environment variable is set
+	 */
+	UFUNCTION(BlueprintPure, Category = "Edgegap Integration Kit | Server")
+	bool IsRunningOnEdgegap() const;
+
+	/**
+	 * Get the current deployment request ID from environment
+	 * @param RequestID - Output parameter for the request ID
+	 * @return True if request ID was found
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Edgegap Integration Kit | Server")
+	bool GetDeploymentRequestID(FString& RequestID) const;
+
+	/** Event fired when server shutdown API call completes */
+	UPROPERTY(BlueprintAssignable, Category = "Edgegap Integration Kit | Server")
+	FOnServerShutdown OnServerShutdown;
+
+private:
+	/** The deployment request ID from environment */
+	FString CachedRequestID;
+
+	/** Whether we're running on Edgegap (have request ID) */
+	bool bIsEdgegapEnvironment;
+
+	/** Flag to prevent multiple shutdown calls */
+	bool bShutdownInitiated;
+
+	/** Handle for shutdown request */
+	TSharedPtr<class IHttpRequest> ShutdownRequest;
+
+	/** Callback for shutdown API response */
+	void OnShutdownResponseReceived(TSharedPtr<IHttpRequest> HttpRequest, TSharedPtr<IHttpResponse> HttpResponse, bool bArg);
+
+	/** Internal method to stop deployment */
+	void StopDeploymentInternal(const FString& RequestID);
+
+	/** Setup crash handlers */
+	void SetupCrashHandlers();
+
+	/** Setup shutdown hooks */
+	void SetupShutdownHooks();
+
+	/** Static crash handler callback */
+	static void StaticCrashHandler(const TCHAR* ErrorMessage, bool bIsAssert);
+
+	/** Console command handler for RequestExit */
+	void HandleRequestExitCommand();
+};
+

--- a/StartServer.sh
+++ b/StartServer.sh
@@ -5,4 +5,60 @@ GAME_PORT=$(echo $ARBITRIUM_PORTS_MAPPING | jq '.ports.gameport.internal')
 printenv
 env
 
-$(dirname "$0")/<PROJECT_NAME>Server.sh -log -PORT=$GAME_PORT 
+# Function to call Edgegap self-stop API
+call_stop_api() {
+    local EXIT_CODE=$1
+    # Try multiple possible environment variable names for request ID
+    local REQUEST_ID="${EG_REQUEST_ID:-${EDGEGAP_REQUEST_ID:-${EDGE_REQUEST_ID:-${ARBITRIUM_REQUEST_ID}}}}"
+    
+    # API key may not be available as env var (typically stored in config)
+    # Try environment first, then common config locations
+    local API_KEY="${EG_API_KEY:-${EDGEGAP_API_KEY:-${EDGE_API_KEY}}}"
+    
+    # If API key not in env, try reading from config file (if available)
+    if [ -z "$API_KEY" ] && [ -f "${UE_PROJECT_DIR}/Saved/Config/LinuxServer/DefaultEngine.ini" ]; then
+        API_KEY=$(grep -m 1 "^AuthorizationKey=" "${UE_PROJECT_DIR}/Saved/Config/LinuxServer/DefaultEngine.ini" 2>/dev/null | cut -d'=' -f2 | tr -d ' ')
+    fi
+    
+    if [ -z "$REQUEST_ID" ]; then
+        echo "No Edgegap request ID found in environment variables (checked: EG_REQUEST_ID, EDGEGAP_REQUEST_ID, EDGE_REQUEST_ID, ARBITRIUM_REQUEST_ID)"
+        echo "Note: The C++ subsystem may still call the self-stop API if it has access to the request ID"
+        exit $EXIT_CODE
+    fi
+    
+    if [ -z "$API_KEY" ]; then
+        echo "No Edgegap API key found (checked env vars and config file)"
+        echo "Note: The C++ subsystem may still call the self-stop API if it has access to the API key from config"
+        exit $EXIT_CODE
+    fi
+    
+    echo "Calling Edgegap self-stop API for request ID: $REQUEST_ID"
+    
+    # Call the self-stop API
+    RESPONSE=$(curl -s -w "\n%{http_code}" -X DELETE \
+        -H "Content-Type: application/json" \
+        -H "Authorization: $API_KEY" \
+        "https://api.edgegap.com/v1/stop/$REQUEST_ID" \
+        --max-time 5)
+    
+    HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+    BODY=$(echo "$RESPONSE" | sed '$d')
+    
+    if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+        echo "Successfully called self-stop API (HTTP $HTTP_CODE)"
+    else
+        echo "Self-stop API call returned HTTP $HTTP_CODE: $BODY"
+    fi
+    
+    exit $EXIT_CODE
+}
+
+# Trap exit signals to call stop API
+trap 'call_stop_api $?' EXIT INT TERM
+
+# Run the server
+$(dirname "$0")/<PROJECT_NAME>Server.sh -log -PORT=$GAME_PORT
+SERVER_EXIT_CODE=$?
+
+# If server exits normally, call stop API with its exit code
+call_stop_api $SERVER_EXIT_CODE


### PR DESCRIPTION
# EdgeGap Requests

1.EGIK support for UE 5.6,
2.EGIK exit and crash handling + calling self-stop API if the server exits with RequestExit 
3.EGIK matchmaking API requests' callback for rate limiting 429 responses separate from 5xx or other errors,
4. update EGIK fab version to include assignment details for Backfills creation blueprint,